### PR TITLE
fix bug https://github.com/Moult/pyttyplay/issues/2#issue-2840549614

### DIFF
--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -942,8 +942,8 @@ class Screen:
         if mo.DECSCNM in modes:
             for line in self._buffer.values():
                 line.default.style = line.default.style._replace(reverse=True)
-                for char in line.values():
-                    char.style = char.style._replace(reverse=True)
+                for k, char in line.items():
+                    line[k] = char._replace(reverse=True)
 
             self.select_graphic_rendition(7)  # +reverse.
 
@@ -980,8 +980,8 @@ class Screen:
         if mo.DECSCNM in modes:
             for line in self._buffer.values():
                 line.default.style = line.default.style._replace(reverse=False)
-                for char in line.values():
-                    char.style = char.style._replace(reverse=False)
+                for k, char in line.items():
+                    line[k] = char._replace(reverse=False)
 
             self.select_graphic_rendition(27)  # -reverse.
 


### PR DESCRIPTION
Object attribute 'style' got lost at some point, I guess; so need to call the method directly on the object from now on.

Works on the ttyrec I tried in the issue https://github.com/Moult/pyttyplay/issues/2#issue-2840549614